### PR TITLE
Extra Keys in github-sshd

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17672,16 +17672,15 @@
         "tullia": "tullia_5"
       },
       "locked": {
-        "lastModified": 1679067040,
-        "narHash": "sha256-53Ga6JsLlEg0WTcGTlu+DWJ3l/7PV5i0F4RhJjooY/U=",
+        "lastModified": 1679418979,
+        "narHash": "sha256-jwuj/Npz34qv6d6A3zXn2LOva9p2WXTOeyLKOxjZ7r8=",
         "owner": "input-output-hk",
         "repo": "marlowe-cardano",
-        "rev": "b977d31ac74607abcf59e82efd812fe58fa92760",
+        "rev": "de3e5f76cf19042978bb5c232d7b1a13eb0ebe0f",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "jhbertra/deployment",
         "repo": "marlowe-cardano",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
     tullia.url = "github:input-output-hk/tullia";
     terranix.url = "github:terranix/terranix";
     sops-nix.url = "github:Mic92/sops-nix";
-    marlowe-cardano.url = "github:input-output-hk/marlowe-cardano?ref=jhbertra/deployment";
+    marlowe-cardano.url = "github:input-output-hk/marlowe-cardano";
   };
 
   outputs = inputs: let

--- a/nix/cloud/nomadEnvs/default.nix
+++ b/nix/cloud/nomadEnvs/default.nix
@@ -5,6 +5,7 @@
   inherit (inputs.data-merge) append merge update;
   inherit (inputs.bitte-cells) patroni tempo vector;
   inherit (inputs.cardano-world) cardano;
+  inherit (inputs.nixpkgs.lib) concatStringsSep;
   inherit (cell) constants nomadTasks;
 
   mkDbSyncJob = environment: let
@@ -129,6 +130,10 @@ in {
           meta = {
             github_teams = "marlowe marlowe-admin";
             entrypoint = "ssh-marlowe";
+            extra_keys = concatStringsSep " " [
+              # marlowe-cardano Github Actions
+              "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHKVEWw43E1Uvc8JT89EX8PD5uCQoJfbDn+A6PEmUfaT marlowebuild@iohk.io"
+            ];
           };
           template = append [
             {

--- a/nix/cloud/nomadEnvs/default.nix
+++ b/nix/cloud/nomadEnvs/default.nix
@@ -5,7 +5,6 @@
   inherit (inputs.data-merge) append merge update;
   inherit (inputs.bitte-cells) patroni tempo vector;
   inherit (inputs.cardano-world) cardano;
-  inherit (inputs.nixpkgs.lib) concatStringsSep;
   inherit (cell) constants nomadTasks;
 
   mkDbSyncJob = environment: let
@@ -130,10 +129,10 @@ in {
           meta = {
             github_teams = "marlowe marlowe-admin";
             entrypoint = "ssh-marlowe";
-            extra_keys = concatStringsSep " " [
+            extra_keys = ''
               # marlowe-cardano Github Actions
-              "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHKVEWw43E1Uvc8JT89EX8PD5uCQoJfbDn+A6PEmUfaT marlowebuild@iohk.io"
-            ];
+              ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHKVEWw43E1Uvc8JT89EX8PD5uCQoJfbDn+A6PEmUfaT marlowebuild@iohk.io
+            '';
           };
           template = append [
             {

--- a/nix/cloud/nomadTasks.nix
+++ b/nix/cloud/nomadTasks.nix
@@ -12,7 +12,11 @@ in {
       SSHD_CONFIG = "/local/sshd_config";
       HOST_KEYS = "/secrets/ssh_host_rsa_key /secrets/ssh_host_ed25519_key";
     };
-    meta.host_keys_dir = "/"; # documenting default value
+    meta = {
+      # Default Values
+      host_keys_dir = "/";
+      extra_keys = "";
+    };
     template = [
       {
         change_mode = "restart";

--- a/nix/cloud/nomadTasks.nix
+++ b/nix/cloud/nomadTasks.nix
@@ -26,7 +26,6 @@ in {
           HOST_KEYS_DIR={{ env "NOMAD_META_host_keys_dir" }}
           GITHUB_TEAMS={{ env "NOMAD_META_github_teams" }}
           GITHUB_TOKEN={{ .Data.data.token }}
-          EXTRA_KEYS={{ env "NOMAD_META_extra_keys" | toJSON }}
           {{ end -}}
         '';
         destination = "/secrets/github-token.env";
@@ -49,6 +48,14 @@ in {
           {{- with secret $keyPath }}{{ .Data.data.ed25519 }}{{ end -}}
         '';
         destination = "/secrets/ssh_host_ed25519_key";
+      }
+      {
+        change_mode = "restart";
+        data = ''
+          EXTRA_KEYS={{ env "NOMAD_META_extra_keys" | toJSON }}
+        '';
+        destination = "/local/extra_keys.env";
+        env = true;
       }
       {
         data = ''

--- a/nix/cloud/nomadTasks.nix
+++ b/nix/cloud/nomadTasks.nix
@@ -26,7 +26,7 @@ in {
           HOST_KEYS_DIR={{ env "NOMAD_META_host_keys_dir" }}
           GITHUB_TEAMS={{ env "NOMAD_META_github_teams" }}
           GITHUB_TOKEN={{ .Data.data.token }}
-          EXTRA_KEYS={{ env "NOMAD_META_extra_keys" }}
+          EXTRA_KEYS={{ env "NOMAD_META_extra_keys" | toJSON }}
           {{ end -}}
         '';
         destination = "/secrets/github-token.env";

--- a/nix/cloud/nomadTasks.nix
+++ b/nix/cloud/nomadTasks.nix
@@ -22,6 +22,7 @@ in {
           HOST_KEYS_DIR={{ env "NOMAD_META_host_keys_dir" }}
           GITHUB_TEAMS={{ env "NOMAD_META_github_teams" }}
           GITHUB_TOKEN={{ .Data.data.token }}
+          EXTRA_KEYS={{ env "NOMAD_META_extra_keys" }}
           {{ end -}}
         '';
         destination = "/secrets/github-token.env";

--- a/nix/cloud/operables.nix
+++ b/nix/cloud/operables.nix
@@ -93,15 +93,15 @@ in {
 
       if [ -n "''${EXTRA_KEYS:-}" ]
       then
-        cat >> /etc/ssh/authorized_keys <<- EOF
+      cat >> /etc/ssh/authorized_keys <<- EOF
 
-          ##############
-          # Extra keys #
-          ##############
+        ##############
+        # Extra keys #
+        ##############
 
-          $(echo -e "$EXTRA_KEYS")
+        $(echo -e "$EXTRA_KEYS")
 
-          # END
+        # END
       EOF
       fi
 

--- a/nix/cloud/operables.nix
+++ b/nix/cloud/operables.nix
@@ -35,7 +35,7 @@ in {
       # GITHUB_TOKEN (required): token of user to query info about teams
       # GITHUB_TEAMS (required): space separated list of github teams to authorize
       # HOST_KEYS (required): path to host keys to pass to the ssh daemon
-      # EXTRA_KEYS (optional): space separated list (read three items at a time) of public key entries in OPENSSH format to add to authorized_keys
+      # EXTRA_KEYS (optional): newline separated list of public key entries in OPENSSH format to add to authorized_keys
 
       [ -z "''${SSHD_CONFIG:-}" ] && echo "SSHD_CONFIG env var must be set -- aborting" && exit 1
       [ -z "''${GITHUB_TOKEN:-}" ] && echo "GITHUB_TOKEN env var must be set -- aborting" && exit 1
@@ -91,18 +91,19 @@ in {
             >> /etc/ssh/authorized_keys
       done
 
-      [ -z "''${$EXTRA_KEYS:-}" ] || echo "" >> /etc/ssh/authorized_keys
-      [ -z "''${$EXTRA_KEYS:-}" ] || echo "##############" >> /etc/ssh/authorized_keys
-      [ -z "''${$EXTRA_KEYS:-}" ] || echo "# Extra keys #" >> /etc/ssh/authorized_keys
-      [ -z "''${$EXTRA_KEYS:-}" ] || echo "##############" >> /etc/ssh/authorized_keys
-      [ -z "''${$EXTRA_KEYS:-}" ] || echo "" >> /etc/ssh/authorized_keys
+      if [ -z "''${EXTRA_KEYS:-}" ]
+      then
+        cat >> /etc/ssh/authorized_keys <<- EOF
 
-      for ALGORITHM KEY IDENTITY in $EXTRA_KEYS; do
-        echo $ALGORITHM $KEY $IDENTITY >> /etc/ssh/authorized_keys
-        echo "" >> /etc/ssh/authorized_keys
-      done
+          ##############
+          # Extra keys #
+          ##############
 
-      [ -z "''${$EXTRA_KEYS:-}" ] || echo "# END>> /etc/ssh/authorized_keys
+          $EXTRA_KEYS
+
+          # END
+      EOF
+      fi
 
       HOST_KEYS_ARG=$(IFS=' '; for KEY in $HOST_KEYS; do echo -n "-o HostKey=$KEY "; done)
 

--- a/nix/cloud/operables.nix
+++ b/nix/cloud/operables.nix
@@ -91,7 +91,7 @@ in {
             >> /etc/ssh/authorized_keys
       done
 
-      if [ -z "''${EXTRA_KEYS:-}" ]
+      if [ -n "''${EXTRA_KEYS:-}" ]
       then
         cat >> /etc/ssh/authorized_keys <<- EOF
 
@@ -99,7 +99,7 @@ in {
           # Extra keys #
           ##############
 
-          $EXTRA_KEYS
+          $(echo -e "$EXTRA_KEYS")
 
           # END
       EOF

--- a/nix/cloud/operables.nix
+++ b/nix/cloud/operables.nix
@@ -35,6 +35,7 @@ in {
       # GITHUB_TOKEN (required): token of user to query info about teams
       # GITHUB_TEAMS (required): space separated list of github teams to authorize
       # HOST_KEYS (required): path to host keys to pass to the ssh daemon
+      # EXTRA_KEYS (optional): space separated list (read three items at a time) of public key entries in OPENSSH format to add to authorized_keys
 
       [ -z "''${SSHD_CONFIG:-}" ] && echo "SSHD_CONFIG env var must be set -- aborting" && exit 1
       [ -z "''${GITHUB_TOKEN:-}" ] && echo "GITHUB_TOKEN env var must be set -- aborting" && exit 1
@@ -89,6 +90,19 @@ in {
             --github-team="$TEAM" \
             >> /etc/ssh/authorized_keys
       done
+
+      [ -z "''${$EXTRA_KEYS:-}" ] || echo "" >> /etc/ssh/authorized_keys
+      [ -z "''${$EXTRA_KEYS:-}" ] || echo "##############" >> /etc/ssh/authorized_keys
+      [ -z "''${$EXTRA_KEYS:-}" ] || echo "# Extra keys #" >> /etc/ssh/authorized_keys
+      [ -z "''${$EXTRA_KEYS:-}" ] || echo "##############" >> /etc/ssh/authorized_keys
+      [ -z "''${$EXTRA_KEYS:-}" ] || echo "" >> /etc/ssh/authorized_keys
+
+      for ALGORITHM KEY IDENTITY in $EXTRA_KEYS; do
+        echo $ALGORITHM $KEY $IDENTITY >> /etc/ssh/authorized_keys
+        echo "" >> /etc/ssh/authorized_keys
+      done
+
+      [ -z "''${$EXTRA_KEYS:-}" ] || echo "# END>> /etc/ssh/authorized_keys
 
       HOST_KEYS_ARG=$(IFS=' '; for KEY in $HOST_KEYS; do echo -n "-o HostKey=$KEY "; done)
 

--- a/nix/marlowe/nomadEnvs/default.nix
+++ b/nix/marlowe/nomadEnvs/default.nix
@@ -1,5 +1,9 @@
-{inputs, cell}: let
+{
+  inputs,
+  cell,
+}: let
   inherit (inputs) data-merge cardano-world nixpkgs bitte-cells cells marlowe-cardano;
+  inherit (cells) cloud;
 
   inherit (cardano-world) cardano;
   inherit (bitte-cells) vector;
@@ -7,7 +11,7 @@
   inherit (nixpkgs.lib) genAttrs head splitString concatStringsSep toUpper replaceStrings;
 
   inherit (marlowe-cardano) nomadTasks;
-  inherit (cells.cloud.constants) baseDomain;
+  inherit (cloud.constants) baseDomain;
 
   # ports to configure for each task
   servicePorts = [
@@ -127,5 +131,54 @@ in {
     marlowe-runtime-preprod = mkRuntimeJob "preprod";
     marlowe-runtime-preview = mkRuntimeJob "preview";
     marlowe-runtime-mainnet = mkRuntimeJob "mainnet";
+    sshd-github.job.sshd-github = {
+      id = "sshd-github";
+      namespace = "marlowe";
+      datacenters = ["us-east-1" "eu-central-1" "eu-west-1"];
+      type = "service";
+      priority = 50;
+
+      group.sshd-github = {
+        network.port.ssh.to = 22;
+        task.sshd-github = merge cloud.nomadTasks.sshd-github {
+          meta = {
+            github_teams = "marlowe marlowe-admin";
+            entrypoint = "ssh-marlowe";
+            extra_keys = ''
+              # marlowe-cardano Github Actions
+              ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHKVEWw43E1Uvc8JT89EX8PD5uCQoJfbDn+A6PEmUfaT marlowebuild@iohk.io
+            '';
+          };
+          template = append [
+            {
+              destination = "/local/network.env";
+              change_mode = "noop";
+              data = ''
+                #!/bin/bash
+                {{- range services }}
+                {{- if .Name | contains "marlowe-runtime" }}
+                {{- range service .Name }}
+                {{-
+                  $environment := .Name
+                                  | regexReplaceAll "marlowe-runtime-(.*)-marlowe-runtime-(.*)" "$1"
+                                  | toUpper
+                -}}
+                {{-
+                  $portname := .Name
+                               | regexReplaceAll "marlowe-runtime-(.*)-marlowe-runtime-(.*)" "$2"
+                               | replaceAll "-" "_"
+                               | toUpper
+                -}}
+                {{ $environment }}_{{$portname}}_IP={{ .Address }}
+                {{ $environment }}_{{$portname}}_PORT={{ .Port }}
+                {{ end -}}
+                {{ end -}}
+                {{ end -}}
+              '';
+            }
+          ];
+        };
+      };
+    };
   };
 }

--- a/nix/marlowe/nomadEnvs/default.nix
+++ b/nix/marlowe/nomadEnvs/default.nix
@@ -160,12 +160,12 @@ in {
                 {{- range service .Name }}
                 {{-
                   $environment := .Name
-                                  | regexReplaceAll "marlowe-runtime-(.*)-marlowe-runtime-(.*)" "$1"
+                                  | regexReplaceAll "marlowe-runtime-(.*)-main-(.*)" "$1"
                                   | toUpper
                 -}}
                 {{-
                   $portname := .Name
-                               | regexReplaceAll "marlowe-runtime-(.*)-marlowe-runtime-(.*)" "$2"
+                               | regexReplaceAll "marlowe-runtime-(.*)-main-(.*)" "$2"
                                | replaceAll "-" "_"
                                | toUpper
                 -}}


### PR DESCRIPTION
Adds a new argument for adding additional keys to github-sshd. This is useful for authenticating from GitHub Actions (or other CI workflows) where a user's ssh private key is not installed (and should not be).